### PR TITLE
Fix a typo

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -14,7 +14,7 @@ import SEO from "../components/seo"
 const BlogPostTemplate = ({ data: { previous, next, post } }) => {
   const featuredImage = {
     fluid: post.featuredImage?.node?.localFile?.childImageSharp?.fluid,
-    alt: post.featuredImage?.node?.alt || ``,
+    alt: post.featuredImage?.node?.altText || ``,
   }
 
   return (


### PR DESCRIPTION
The reference name of the 'altText' field was 'alt'.
https://www.wpgraphql.com/docs/media/#list-of-media-items