### PR TITLE
Update gatsby-source-wordpress to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gatsby-plugin-react-helmet": "^3.8.0",
     "gatsby-plugin-sharp": "^2.12.0",
     "gatsby-source-filesystem": "^2.9.0",
-    "gatsby-source-wordpress": "^4.0.0",
+    "gatsby-source-wordpress": "^4.0.3",
     "gatsby-transformer-sharp": "^2.9.0",
     "html-react-parser": "^1.1.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
Fixes an error with createSchemaCustomization, causing builds to fail with current versions of WPGatsby and WPGraphQL